### PR TITLE
Fix for #1

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ eclipse_owner_home: "{{ home }}"
 eclipse_base_dir: "/usr/local/eclipse"
 eclipse_link_base_dir: "/opt"
 eclipse_dir_tmp: "/tmp" # or override with "{{ tempdir.stdout }} in order to have be sure to download the file"
-
+cur_dir: "{{lookup('pipe','pwd')}}"
 ## Most likely you dont need to edit 
 #todo eclipse_service_enabled   : 'yes'
 eclipse_major: "4"

--- a/tasks/eclipse.yml
+++ b/tasks/eclipse.yml
@@ -16,13 +16,16 @@
   register: tempdir
   tags: eclipse_setup
 
-- name: eclipse | Download eclipse
-  get_url:
-    url="{{eclipse_url}}"
-    dest="{{ eclipse_dir_tmp }}/{{eclipse_archive}}"
+- name: eclipse | Download eclipse on 'master' if we don't have it
+  connection: local
+  sudo: False
+  get_url: url={{eclipse_url}}  dest={{cur_dir}}/{{eclipse_archive}} force=no
+
+- name: Copy eclipse into place
+  copy: src={{eclipse_archive}}  dest="{{ eclipse_dir_tmp }}/{{eclipse_archive}}" owner="{{eclipse_owner}}" group="{{eclipse_group}}" mode=644
   register: eclipse_download
   tags: eclipse_setup
-
+  
 - name: eclipse | Create base directory
   file:
     dest="{{eclipse_base_dir}}/eclipse-{{eclipse_name}}"


### PR DESCRIPTION
Downloading Eclipse without a mirror is a drag, this uses a cached tarball in the 'files' directory of the role.
