### PR TITLE
Some fixes for CentOS

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,10 +14,10 @@ cur_dir: "{{lookup('pipe','pwd')}}"
 ## Most likely you dont need to edit 
 #todo eclipse_service_enabled   : 'yes'
 eclipse_major: "4"
-eclipse_minor: "4"
+eclipse_minor: "5"
 #kepler 3.7.2.1
 eclipse_version: "{{eclipse_major}}.{{eclipse_minor}}"
-eclipse_name: "luna"
+eclipse_name: "mars"
 eclipse_archive_extracted: "eclipse"
 #eclipse_archive: "eclipse-jee-kepler-SR2-linux-gtk-x86_64.tar.gz"
 #modeling
@@ -25,14 +25,14 @@ eclipse_archive_extracted: "eclipse"
 #java
 #eclipse_archive: "eclipse-java-{{eclipse_name}}-SR1-linux-gtk-x86_64.tar.gz"
 #javaee
-eclipse_archive: "eclipse-jee-{{eclipse_name}}-SR1-linux-gtk-x86_64.tar.gz"
+eclipse_archive: "eclipse-jee-{{eclipse_name}}-1-linux-gtk-x86_64.tar.gz"
 
 #modeling
 #eclipse_url: "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/{{eclipse_name}}/R/{{eclipse_archive}}&r=1"
 #java
 #eclipse_url: "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/{{eclipse_name}}/SR1/{{eclipse_archive}}&r=1"
 #javaee
-eclipse_url: "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/{{eclipse_name}}/SR1/{{eclipse_archive}}&r=1"
+eclipse_url: "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/{{eclipse_name}}/1/{{eclipse_archive}}&r=1"
 eclipse_home_dir: "{{eclipse_base_dir}}/{{eclipse_name}}-{{eclipse_version}}"
 
 eclipse_plugins_enabled: yes                          # Enable plugins

--- a/files/add_pydev_certificate.py
+++ b/files/add_pydev_certificate.py
@@ -2,25 +2,45 @@
 # Add PyDev's certificate to Java's key and certificate database
 # Certificate file here: http://pydev.org/pydev_certificate.cer
 import os, sys, pexpect, urllib2
+
+def find_java_home():
+
+    if os.environ['JAVA_HOME']:
+        return os.environ['JAVA_HOME']
+
+    import subprocess
+    return_value=subprocess.call('which java',stdin=java_path)
+
+    if not return_value:
+        return java_path.replace('bin/java','')
+
+    # fall back to original path..
+    return '/usr/lib/jvm/default-java'
+
+
 def main():
-  # NOTE: You may have to update the path to your system's cacerts file
-  certs_file = '/usr/lib/jvm/default-java/jre/lib/security/cacerts'  
-  pydev_certs_url = 'http://pydev.org/pydev_certificate.cer'
-  print "Adding pydev_certificate.cer to %s" % (certs_file)
-  pydev_cert = open('pydev_certificate.cer', 'w')
-  pydev_cert.write(urllib2.urlopen(pydev_certs_url).read())
-  pydev_cert.close()
-  cmd = "keytool -import -file ./pydev_certificate.cer -keystore %s" % (certs_file)
-  child = pexpect.spawn(cmd)
-  child.expect("Enter keystore password:")
-  child.sendline("changeit")
-  if child.expect(["Trust this certificate?", "already exists"]) == 0:
-    child.sendline("yes")
-  #try:
-  #  child.interact()
-  #except OSError:
-  #  pass  
-  print "done"
+    # NOTE: You may have to update the path to your system's cacerts file
+
+    certs_file = os.path.join(find_java_home(), 'jre/lib/security/cacerts')
+    if not os.path.isfile(certs_file):
+        raise ValuError('Wrong path to certs file')
+
+    pydev_certs_url = 'http://pydev.org/pydev_certificate.cer'
+    print "Adding pydev_certificate.cer to %s" % (certs_file)
+    pydev_cert = open('pydev_certificate.cer', 'w')
+    pydev_cert.write(urllib2.urlopen(pydev_certs_url).read())
+    pydev_cert.close()
+    cmd = "keytool -import -file ./pydev_certificate.cer -keystore %s" % (certs_file)
+    child = pexpect.spawn(cmd)
+    child.expect("Enter keystore password:")
+    child.sendline("changeit")
+    if child.expect(["Trust this certificate?", "already exists"]) == 0:
+        child.sendline("yes")
+    #try:
+    #    child.interact()
+    #except OSError:
+    #    pass
+    print "done"
 
 if __name__ == "__main__":
   main()

--- a/tasks/eclipse.yml
+++ b/tasks/eclipse.yml
@@ -203,12 +203,17 @@
   ignore_errors: True
 
 #Pydev
-- name: eclipse | Install python pexpect for adding Pydev certificat
+- name: eclipse | Install python pexpect for adding Pydev certificat (apt)
   apt: pkg={{ item }} state=present
-  when: ansible_distribution == 'Debian'
   with_items:
     - python-pexpect
-  when: eclipse_plugins_pydev_enabled and eclipse_plugins_enabled
+  when: eclipse_plugins_pydev_enabled and eclipse_plugins_enabled and ansible_distribution == 'Debian'
+
+- name: eclipse | Install python pexpect for adding Pydev certificat (yum)
+  yum: name={{ item }} state=present
+  with_items:
+    - pexpect
+  when: eclipse_plugins_pydev_enabled and eclipse_plugins_enabled and ansible_distribution == 'CentOS'
 
 #todo for RehHat : sudo yum install pexpect.noarch
 

--- a/tasks/eclipse.yml
+++ b/tasks/eclipse.yml
@@ -36,11 +36,15 @@
   when: eclipse_download.changed
   tags: eclipse_setup
 
-- name: eclipse | Install tar
-  apt:
-    pkg=tar
-    state="present"
+- name: eclipse | Install tar (apt)
+  apt: name=tar state=present
   tags: eclipse_setup
+  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+
+- name: eclipse | Install tar (yum)
+  yum: name=tar state=present
+  tags: eclipse_setup
+  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
 
 - name: eclipse | Extract archive eclipse
   command: tar xzf {{ eclipse_dir_tmp }}/{{eclipse_archive}} -C {{eclipse_base_dir}}/eclipse-{{eclipse_name}} --strip-components=1

--- a/tasks/eclipse.yml
+++ b/tasks/eclipse.yml
@@ -233,10 +233,9 @@
 - name: eclipse | Install JavaHL for subclipse
   apt: pkg={{ item }} state=present
   sudo: yes
-  when: ansible_distribution == 'Debian'
   with_items:
     - libsvn-java
-  when: eclipse_plugins_subclipse_enabled and eclipse_plugins_enabled
+  when: eclipse_plugins_subclipse_enabled and eclipse_plugins_enabled and ansible_distribution == 'Debian'
 
 - name: eclipse | Install eclipse Subversion plugins
   command: "{{eclipse_base_dir}}/eclipse-{{eclipse_major}}/eclipse -nosplash \

--- a/tasks/eclipse.yml
+++ b/tasks/eclipse.yml
@@ -32,11 +32,6 @@
   become: yes
   when: eclipse_download.changed
 
-- name: eclipse | Install tar (yum)
-  yum: name=tar state=present
-  tags: eclipse_setup
-  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
-
 - name: eclipse | Create a link to eclipse (2)
   file:
     src="{{ eclipse }}"

--- a/tasks/eclipse.yml
+++ b/tasks/eclipse.yml
@@ -230,12 +230,19 @@
   ignore_errors: True
 
 #Subclipse
-- name: eclipse | Install JavaHL for subclipse
+- name: eclipse | Install JavaHL for subclipse (apt)
   apt: pkg={{ item }} state=present
   sudo: yes
   with_items:
     - libsvn-java
   when: eclipse_plugins_subclipse_enabled and eclipse_plugins_enabled and ansible_distribution == 'Debian'
+
+- name: eclipse | Install JavaHL for subclipse (yum)
+  yum: name={{ item }} state=present
+  sudo: yes
+  with_items:
+    - subversion-javahl
+  when: eclipse_plugins_subclipse_enabled and eclipse_plugins_enabled and ansible_distribution == 'CentOS'
 
 - name: eclipse | Install eclipse Subversion plugins
   command: "{{eclipse_base_dir}}/eclipse-{{eclipse_major}}/eclipse -nosplash \

--- a/tasks/install_CentOS.yml
+++ b/tasks/install_CentOS.yml
@@ -1,0 +1,45 @@
+
+- set_fact: eclipse_home={{ eclipse_home_dir }}
+
+- set_fact: eclipse="{{ eclipse_home_dir }}/eclipse"
+
+- name: eclipse | Download eclipse on 'master' if we don't have it
+  connection: local
+  get_url: url={{ eclipse_url }} dest={{ eclipse_dir_tmp }}/{{ eclipse_archive }} force=no
+  register: eclipse_download
+
+- name: eclipse | Copy eclipse into place
+  copy: src={{ eclipse_dir_tmp }}/{{ eclipse_archive }} dest="{{ eclipse_dir_tmp }}/{{ eclipse_archive }}" owner="{{ eclipse_owner }}" group="{{ eclipse_group }}" mode=644
+  become: true
+  tags: eclipse_setup
+
+- name: eclipse | Create base directory
+  file:
+    dest="{{ eclipse_home }}"
+    state=directory
+    owner="{{ eclipse_owner }}"
+    group="{{ eclipse_group }}"
+  become: true
+  when: eclipse_download.changed
+  tags: eclipse_setup
+
+#TODO
+#- unarchive: src=/tmp/eclipse.tar.gz dest=/opt
+
+- name: eclipse | Install tar
+  yum: name=tar state=present
+  tags: eclipse_setup
+
+- name: eclipse | Extract archive eclipse
+  command: tar xzf {{ eclipse_dir_tmp }}/{{ eclipse_archive }} -C {{ eclipse_home }} --strip-components=1
+  when: eclipse_download.changed
+
+- name: eclipse | Change archive eclipse ownership
+  file: path={{ eclipse_home }} owner={{ eclipse_owner }} state=directory recurse=yes
+  when: eclipse_download.changed
+
+- name: eclipse | Configure eclipse icon
+  template: src=eclipse.desktop.j2 dest={{ eclipse_desktop }}
+  when: (ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu')
+  ignore_errors: yes
+  tags: eclipse_setup

--- a/tasks/install_CentOS.yml
+++ b/tasks/install_CentOS.yml
@@ -39,7 +39,7 @@
   when: eclipse_download.changed
 
 - name: eclipse | Configure eclipse icon
-  template: src=eclipse.desktop.j2 dest={{ eclipse_desktop }}
-  when: (ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu')
+  template: src=eclipse.desktop.j2 dest=/usr/local/share/applications/eclipse.desktop
+  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
   ignore_errors: yes
   tags: eclipse_setup


### PR DESCRIPTION
- in files/add_pydev_certificate.py I propose a change to make the cacerts discovery somewhat safer (?)
- Some of the yum packages are now installed

This has been tested on CentOS 7.1 which uses ansible 1.9. That means that the newer dynamic include commands don't work so I had to copy in the content into tasks/eclipse.yml to check the correctness. In our branch esss I will make those modifications and also change default settings (it is the branch we build from at our lab).

These changes seem to work correctly on my machine. Please check that I have not screwed up anything for Debian/Ubuntu.
