### PR TITLE
Minor fixes

### DIFF
--- a/tasks/eclipse.yml
+++ b/tasks/eclipse.yml
@@ -24,7 +24,7 @@
 
 - name: eclipse | Create a link to eclipse (1)
   file:
-    src="{{ eclipse }}"
+    src="{{ eclipse_home }}"
     dest="{{ eclipse_base_dir }}/eclipse-{{ eclipse_major }}"
     state=link
     owner="{{ eclipse_owner }}"
@@ -34,7 +34,7 @@
 
 - name: eclipse | Create a link to eclipse (2)
   file:
-    src="{{ eclipse }}"
+    src="{{ eclipse_home }}"
     dest="{{ eclipse_link_base_dir }}/eclipse-{{ eclipse_major }}"
     state=link
     owner="{{ eclipse_owner }}"

--- a/tasks/install_CentOS.yml
+++ b/tasks/install_CentOS.yml
@@ -39,7 +39,7 @@
   when: eclipse_download.changed
 
 - name: eclipse | Configure eclipse icon
-  template: src=eclipse.desktop.j2 dest=/usr/local/share/applications/eclipse.desktop
-  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
+  template: src=eclipse.desktop.j2 dest={{ eclipse_desktop }}
+  when: (ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux')
   ignore_errors: yes
   tags: eclipse_setup


### PR DESCRIPTION
- I discovered that you define eclipse_desktop, so I use that for the install_CentOS as well to follow your structure as much as possible
- I noticed that the soft link /usr/local/eclipse-4 points directly to the binary instead of to the folder. This is either wrong or things such as the desktop file template must be updated (as it assumes it is a soft link to the folder). I assume it was the former.
